### PR TITLE
fix: brew installation

### DIFF
--- a/Formula/terraform-bucket-registry.rb
+++ b/Formula/terraform-bucket-registry.rb
@@ -6,7 +6,6 @@ class TerraformBucketRegistry < Formula
   desc ""
   homepage "https://github.com/meringu/terraform-bucket-registry"
   version "0.1.1"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/meringu/terraform-bucket-registry/releases/download/v0.1.1/terraform-bucket-registry_0.1.1_darwin_amd64.tar.gz"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See https://www.terraform.io/docs/internals/provider-registry-protocol.html for 
 ### MacOS
 
 ```
-brew tap meringu/terraform-bucket-registry
+brew tap meringu/terraform-bucket-registry https://github.com/meringu/terraform-bucket-registry
 brew install terraform-bucket-registry
 ```
 


### PR DESCRIPTION
- use two argument form of brew tap because the one argument form expects a repo named `homebrew-*` see https://docs.brew.sh/Taps#repository-naming-conventions-and-assumptions
- remove deprecated bottle :unneeded
    fixes:
    ```
    Error: Invalid formula: /usr/local/Homebrew/Library/Taps/meringu/homebrew-terraform-bucket-registry/Formula/terraform-bucket-registry.rb
    terraform-bucket-registry: Calling bottle :unneeded is disabled! There is no replacement.
    ```